### PR TITLE
chore: remove dated pr template sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,15 +9,3 @@
 ## Documentation <sub><sup>(that requires updating in Notion / Github)</sup></sub>
 
 ## Post-release Monitoring Plan <sub><sup>(what's your plan to monitor the changes to make sure they have the intended effect)</sup></sub>
-
-## Checklist
-- [ ] Add a brief description, screenshots (if applicable), and testing instructions for this PR.
-- [ ] Introduce or modify relevant documentation
-- [ ] Ensure unhappy paths are considered/tested, and there is a plan for monitoring post-deployment
-- [ ] Test your changes in the deployed PR preview environment / [run migration locally](https://github.com/clearbanc/code/tree/staging/packages/migrations#run-migrations) (if applicable).
-- [ ] Ensure test coverage value in config file match actual coverage (if applicable).
-
-## Jenkins Build Triaging
-To rebuild a this PR in Jenkins comment in this PR with: `@Jenkins rebuild`.
-To unfreeze frozen builds try to close and reopen the PR.
-For further help please reach out to `@infra-help` in `#devops` slack channel.


### PR DESCRIPTION
## Purpose
Removes some sections from our PR template that are either outdated, or just not used in general.

### Explanation for Checklist removal
In my experience this is not leveraged much. If we look at the contents, roughly half of it redundantly covers the PR section headings (purpose, wcgw, monitoring). The remaining two can (and should be) covered by automated PR quality checks as a whole so I don't see much value in them as a part of the PR template.

I feel that there are better methods for (e.g. referencing testing documentation) some of these things rather than defining in a PR template. I prefer the template be saved for covering the Purpose/Intent/Concerns associated with the suggested change.

My personal quantifier for determining what's appropriate here is the following:
> Is this content appropriate or desirable to be included in the resultant commit when the change request is merged.

